### PR TITLE
Add shell cwd option & fix build on windows

### DIFF
--- a/builtin/bins/dkron-executor-shell/shell_unix.go
+++ b/builtin/bins/dkron-executor-shell/shell_unix.go
@@ -1,0 +1,39 @@
+// +build !windows
+
+package main
+
+import (
+	"os/exec"
+	"os/user"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+func setCmdAttr(cmd *exec.Cmd, config map[string]string) error {
+	su, _ := config["su"]
+	if su != "" {
+		var uid, gid int
+		parts := strings.Split(su, ":")
+		u, err := user.Lookup(parts[0])
+		if err != nil {
+			return err
+		}
+		uid, _ = strconv.Atoi(u.Uid)
+		if len(parts) > 1 {
+			g, err := user.LookupGroup(parts[1])
+			if err != nil {
+				return err
+			}
+			gid, _ = strconv.Atoi(g.Gid)
+		} else {
+			gid, _ = strconv.Atoi(u.Gid)
+		}
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+		cmd.SysProcAttr.Credential = &syscall.Credential{
+			Uid: uint32(uid),
+			Gid: uint32(gid),
+		}
+	}
+	return nil
+}

--- a/builtin/bins/dkron-executor-shell/shell_windows.go
+++ b/builtin/bins/dkron-executor-shell/shell_windows.go
@@ -1,0 +1,11 @@
+// +build windows
+
+package main
+
+import (
+	"os/exec"
+)
+
+func setCmdAttr(cmd *exec.Cmd, config map[string]string) error {
+	return nil
+}


### PR DESCRIPTION
Hi, this time I add `cwd` option for shell executor
At the same time, fix build process on Windows, since it has no `syscall.Credential`.