### PR TITLE
fix: comment out process metrics collection code

### DIFF
--- a/plugin/shell/shell.go
+++ b/plugin/shell/shell.go
@@ -130,14 +130,14 @@ func (s *Shell) ExecuteImpl(args *dktypes.ExecuteRequest, cb dkplugin.StatusHelp
 		defer slowTimer.Stop()
 	}
 
-	quit := make(chan int)
-
 	// FIXME: Debug metrics collection
+	// quit := make(chan int)
+
 	// go CollectProcessMetrics(args.JobName, cmd.Process.Pid, quit)
 
-	err = cmd.Wait()
-	quit <- cmd.ProcessState.ExitCode()
-	close(quit) // exit metric refresh goroutine after job is finished
+	// err = cmd.Wait()
+	// quit <- cmd.ProcessState.ExitCode()
+	// close(quit) // exit metric refresh goroutine after job is finished
 
 	if jobTimedOut {
 		_, err := output.Write([]byte(jobTimeoutMessage))


### PR DESCRIPTION
This pull request makes a minor change by commenting out the metric collection logic in the `ExecuteImpl` function of the `plugin/shell/shell.go` file. The change disables the creation and use of the `quit` channel and related goroutine for process metrics collection, likely for debugging or to prevent side effects during execution.