### PR TITLE
fix: initialize SysProcAttr before using it

### DIFF
--- a/plugin/shell/shell_unix.go
+++ b/plugin/shell/shell_unix.go
@@ -32,6 +32,7 @@ func setCmdAttr(cmd *exec.Cmd, config map[string]string) error {
 		} else {
 			gid, _ = strconv.Atoi(u.Gid)
 		}
+		cmd.SysProcAttr.Setpgid = true
 		cmd.SysProcAttr.Credential = &syscall.Credential{
 			Uid: uint32(uid),
 			Gid: uint32(gid),
@@ -39,7 +40,7 @@ func setCmdAttr(cmd *exec.Cmd, config map[string]string) error {
 	}
 
 	jobTimeout := config["timeout"]
-	if jobTimeout != "" && cmd.SysProcAttr == nil {
+	if jobTimeout != "" {
 		cmd.SysProcAttr.Setpgid = true
 	}
 	return nil


### PR DESCRIPTION
Create a default SysProcAttr in setCmdAttr and avoid overwriting it when handling the timeout Setpgid setting

fixes #1689 