### PR TITLE
test: add coverage report generation and upload steps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,3 +34,11 @@ jobs:
 
       - name: Test without docker
         run: go test -v -timeout 200s ./...
+
+      - name: Generate coverage report
+        run: go test -coverprofile=coverage.txt
+        
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
This pull request updates the CI workflow to include code coverage reporting. The main change is the addition of steps to generate a coverage report and upload it to Codecov.

Testing and coverage improvements:

* Added a step to generate a Go coverage report using `go test -coverprofile=coverage.txt` in the workflow file `.github/workflows/test.yml`
* Added a step to upload the generated coverage report to Codecov using the `codecov/codecov-action@v5` GitHub Action, with authentication via `CODECOV_TOKEN`