### PR TITLE
feat: allow to customize exchange in rabbitmq executor

### DIFF
--- a/builtin/bins/dkron-executor-rabbitmq/README.md
+++ b/builtin/bins/dkron-executor-rabbitmq/README.md
@@ -7,6 +7,7 @@ The options names are inherited from the [RabbitMQ Publishers](https://www.rabbi
 | Option                | Required | Description                   | Default    |
 |-----------------------|----------|-------------------------------|------------|
 | url                   | yes      | RabbitMQ connection string    | -          |
+| exchange              | no       | RabbitMQ Exchange             | ""         |
 | queue.name            | yes      | Queue name to send message to | -          |
 | queue.create          | no       | Create queue if not exists    | false      |
 | queue.durable         | no       | Durable queue                 | false      |
@@ -38,6 +39,7 @@ curl localhost:8080/v1/jobs -XPOST -d '{
   "executor": "rabbitmq",
   "executor_config": {
   		"url": "amqp://guest:guest@localhost:5672/",
+      "exchange": "amq.default",
   		"queue.name": "test",
   		"queue.create": "true",
   		"queue.durable": "true",

--- a/builtin/bins/dkron-executor-rabbitmq/rabbitmq.go
+++ b/builtin/bins/dkron-executor-rabbitmq/rabbitmq.go
@@ -19,6 +19,7 @@ type RabbitMQ struct{}
 //
 //	"executor_config": {
 //			"url": "amqp://guest:guest@localhost:5672/",
+//			"exchange": "amq.default",
 //			"queue.name": "test",
 //			"queue.create": "true",
 //			"queue.durable": "true",
@@ -144,8 +145,12 @@ func publish(cfg map[string]string, ch *amqp.Channel) error {
 	if err != nil {
 		return err
 	}
+	exchange, ok := cfg["exchange"]
+	if !ok {
+		exchange = ""
+	}
 	return ch.Publish(
-		"",                // exchange
+		exchange,          // exchange
 		cfg["queue.name"], // routing key
 		false,             // mandatory
 		false,             // immediate

--- a/website/docs/usage/executors/rabbitmq.md
+++ b/website/docs/usage/executors/rabbitmq.md
@@ -17,6 +17,7 @@ message.delivery_mode:       Message delivery mode. 1 for non-persistent, 2 for 
 message.messageId:           The message ID
 message.body:                The actual message body in desired format that will be sent to the queue
 message.base64:              Encoded message body in base64 format. Optional, but should not be set if message.body is set.
+exchange:                    The RabbitMQ exchange. Optional, default to ""
 ```
 
 Example:
@@ -26,6 +27,7 @@ Example:
   "executor": "rabbitmq",
   "executor_config": {
     "url": "amqp://guest:guest@localhost:5672/",
+    "exchange": "amq.default",
     "queue.name": "test",
     "queue.create": "true",
     "queue.durable": "true",


### PR DESCRIPTION
## Proposed changes

The `exchange` is hardcoded with `empty string` in rabbitmq executor, this PR allow user to customize `exchange` in `executor_config`.

```json
{
  "executor": "rabbitmq",
  "executor_config": {
    "url": "amqp://guest:guest@localhost:5672/",
    "exchange": "amq.default",
    "queue.name": "test",
    "queue.create": "true",
    "queue.durable": "true",
    "queue.auto_delete": "false",
    "queue.exclusive": "false",
    "message.content_type": "application/json",
    "message.delivery_mode": "2",
    "message.messageId": "4373732772",
    "message.body": "{\"key\":\"value\"}"
  }
}
```

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
