### PR TITLE
fix: Export job execution metrics to Prometheus

### DIFF
--- a/dkron/job_metrics.go
+++ b/dkron/job_metrics.go
@@ -1,0 +1,31 @@
+package dkron
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	// JobExecutionsSucceededTotal is a counter for successful job executions
+	JobExecutionsSucceededTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "dkron",
+			Subsystem: "job",
+			Name:      "executions_succeeded_total",
+			Help:      "Total number of successful job executions",
+		},
+		[]string{"job_name"},
+	)
+
+	// JobExecutionsFailedTotal is a counter for failed job executions
+	JobExecutionsFailedTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "dkron",
+			Subsystem: "job",
+			Name:      "executions_failed_total",
+			Help:      "Total number of failed job executions",
+		},
+		[]string{"job_name"},
+	)
+)
+

--- a/dkron/store.go
+++ b/dkron/store.go
@@ -292,13 +292,17 @@ func (s *Store) SetExecutionDone(ctx context.Context, execution *Execution) (boo
 			pbj.LastSuccess.Time = pbe.FinishedAt
 			pbj.SuccessCount++
 			// Emit metrics for successful job execution
+			// Use both hashicorp/go-metrics (for statsd) and prometheus/client_golang (for Prometheus)
 			metrics.IncrCounterWithLabels([]string{"job", "executions_succeeded_total"}, 1, []metrics.Label{{Name: "job_name", Value: execution.JobName}})
+			JobExecutionsSucceededTotal.WithLabelValues(execution.JobName).Inc()
 		} else {
 			pbj.LastError.HasValue = true
 			pbj.LastError.Time = pbe.FinishedAt
 			pbj.ErrorCount++
 			// Emit metrics for failed job execution
+			// Use both hashicorp/go-metrics (for statsd) and prometheus/client_golang (for Prometheus)
 			metrics.IncrCounterWithLabels([]string{"job", "executions_failed_total"}, 1, []metrics.Label{{Name: "job_name", Value: execution.JobName}})
+			JobExecutionsFailedTotal.WithLabelValues(execution.JobName).Inc()
 		}
 
 		status, err := s.computeStatus(pbj.Name, pbe.Group, tx)


### PR DESCRIPTION
# Fix: Export job execution metrics to Prometheus

## Problem

In PR #1825, job execution metrics were added using `github.com/armon/go-metrics` package:

```go
metrics.IncrCounterWithLabels([]string{"job", "executions_succeeded_total"}, 1, ...)
metrics.IncrCounterWithLabels([]string{"job", "executions_failed_total"}, 1, ...)
```

However, these metrics are **not exported to Prometheus** even though they are being created.

## Root Cause

The issue is an architectural mismatch between two different metrics systems:

1. **`hashicorp/go-metrics`** (aliased as `github.com/armon/go-metrics`) - Creates metrics in its own internal sink
2. **`prometheus/client_golang`** - Exports metrics from the global Prometheus registry

The HTTP endpoint in `dkron/api.go` uses `promhttp.Handler()` from `prometheus/client_golang`:

```go
r.GET("/metrics", gin.WrapH(promhttp.Handler()))
```

This handler exports metrics from the **global Prometheus registry**, but metrics created via `go-metrics` don't register in this registry. They go to a separate `PrometheusSink` from `hashicorp/go-metrics/prometheus`, which has its own HTTP handler that is **never used** in the API endpoint.

## Why PR #1825 Didn't Work

Looking at the commit history of PR #1825, there were several iterations:
1. "Initial plan"
2. "Add job execution metrics emission"
3. "Implement native Prometheus metrics for job executions"
4. **"Switch to go-metrics package instead of direct Prometheus integration"** ← This is where the problem was introduced

The switch to `go-metrics` was likely made to:
- Use a unified metrics system (for both statsd and prometheus)
- Maintain compatibility with existing code

However, the integration between `go-metrics` Prometheus sink and `promhttp.Handler()` was not properly implemented.

## Solution

This PR adds **direct Prometheus metrics** using `prometheus/client_golang`, similar to how it's done in `plugin/shell/prometheus.go`:

1. **Created `dkron/job_metrics.go`** with Prometheus metric definitions:
   - `dkron_job_executions_succeeded_total{job_name="..."}`
   - `dkron_job_executions_failed_total{job_name="..."}`

2. **Updated `dkron/store.go`** to emit both:
   - `go-metrics` metrics (for statsd compatibility)
   - `prometheus/client_golang` metrics (for Prometheus export)

This ensures:
- ✅ Metrics are registered in the global Prometheus registry
- ✅ Metrics are exported via `promhttp.Handler()`
- ✅ Backward compatibility with statsd (via go-metrics)
- ✅ Follows the same pattern as shell executor metrics

## Testing

The fix has been tested locally:
- Metrics are created when jobs execute
- Metrics appear in `/metrics` endpoint
- Metrics are scraped by Prometheus
- Metrics are visible in Grafana dashboards

Example output:
```
dkron_job_executions_succeeded_total{job_name="test-success-job"} 3
dkron_job_executions_failed_total{job_name="test-failure-job"} 3
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Prometheus metrics for comprehensive job execution monitoring, tracking both successful and failed job executions with job name labels.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->