### PR TITLE
Update contact email in COMM-LICENSE

### DIFF
--- a/COMM-LICENSE
+++ b/COMM-LICENSE
@@ -87,4 +87,4 @@ In no event will Distributed Works' liability exceed the Software license price 
 
 13.10 Headings. The headings of sections and paragraphs of this Agreement are for convenience of reference only and are not intended to restrict, affect or be of any weight in the interpretation or construction of the provisions of such sections or paragraphs.
 
-14. Contact Information. If you have any questions about this EULA, or if you want to contact Distributed Works for any reason, please direct correspondence to support@distrib.works.
+14. Contact Information. If you have any questions about this EULA, or if you want to contact Distributed Works for any reason, please direct correspondence to support@dkron.io


### PR DESCRIPTION
This pull request makes a minor update to the contact information in the `COMM-LICENSE` file, changing the support email address to reflect the current domain. 

- Updated the contact email address from `support@distrib.works` to `support@dkron.io` in the license agreement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the contact email in the License (Contact Information) to support@dkron.io, replacing the previous address.
  * No changes to license terms, product behavior, or functionality; this is an informational update only.
  * Improves accuracy and routing of support and legal inquiries.
  * Users should use the new email for future communications; no action required for product usage or configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->