### PR TITLE
fix(plugin): register executor in pluginMap and enable gRPC in Serve

### DIFF
--- a/plugin/serve.go
+++ b/plugin/serve.go
@@ -30,13 +30,22 @@ func Serve(opts *ServeOpts) {
 	plugin.Serve(&plugin.ServeConfig{
 		HandshakeConfig: Handshake,
 		Plugins:         pluginMap(opts),
+		GRPCServer:      plugin.DefaultGRPCServer,
 	})
 }
 
 // pluginMap returns the map[string]plugin.Plugin to use for configuring a plugin
 // server or client.
 func pluginMap(opts *ServeOpts) map[string]plugin.Plugin {
-	return map[string]plugin.Plugin{
-		"processor": &ProcessorPlugin{Processor: opts.Processor},
+	plugins := map[string]plugin.Plugin{}
+
+	if opts.Processor != nil {
+		plugins[ProcessorPluginName] = &ProcessorPlugin{Processor: opts.Processor}
 	}
+
+	if opts.Executor != nil {
+		plugins[ExecutorPluginName] = &ExecutorPlugin{Executor: opts.Executor}
+	}
+
+	return plugins
 }


### PR DESCRIPTION
## Problem

External executor plugins always crash on startup with:

```
level=fatal msg="unsupported plugin protocol \"netrpc\". Supported: [grpc]"
```

This makes it impossible to use any custom executor plugin with dkron v4.

## Root cause

Two bugs in `plugin/serve.go`:

**1. Missing `GRPCServer` in `Serve()`**

`plugin.Serve()` was called without `GRPCServer: plugin.DefaultGRPCServer`. The `go-plugin` library defaults to `netrpc` when no gRPC server is configured. Since dkron v4 only accepts gRPC, every external plugin is rejected at handshake time.

**2. `pluginMap()` never registers the executor**

`pluginMap()` only registers `"processor"` and ignores `"executor"`, despite `ServeOpts.Executor` and `ExecutorPluginName` being defined. Any plugin calling `Serve()` with an `Executor` is silently ignored — the plugin map is empty for its type.

## Fix

```go
func Serve(opts *ServeOpts) {
    plugin.Serve(&plugin.ServeConfig{
        HandshakeConfig: Handshake,
        Plugins:         pluginMap(opts),
        GRPCServer:      plugin.DefaultGRPCServer, // added
    })
}

func pluginMap(opts *ServeOpts) map[string]plugin.Plugin {
    plugins := map[string]plugin.Plugin{}

    if opts.Processor != nil {
        plugins[ProcessorPluginName] = &ProcessorPlugin{Processor: opts.Processor}
    }

    if opts.Executor != nil {
        plugins[ExecutorPluginName] = &ExecutorPlugin{Executor: opts.Executor} // added
    }

    return plugins
}
```

## Tested

Verified with a custom executor plugin (`dkron-executor-secrethttp`) running on dkron v4.0.9 on Kubernetes (AKS).

- **Before**: all pods in `CrashLoopBackOff` with `unsupported plugin protocol "netrpc"`
- **After**: all pods `Running`, jobs executing correctly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved plugin system configuration to selectively load plugins based on enabled settings.
  * Enhanced plugin server integration for better communication and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->