### PR TITLE
fix: eliminate 'address already in use' errors in test suite

### DIFF
--- a/dkron/agent_test.go
+++ b/dkron/agent_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"net"
 	"os"
 	"sort"
 	"testing"
@@ -14,6 +15,16 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// getFreePort asks the OS for a free port and returns it as a string.
+func getFreePort(t *testing.T) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := l.Addr().(*net.TCPAddr).Port
+	l.Close()
+	return fmt.Sprintf("%d", port)
+}
 
 var (
 	logLevel = "info"
@@ -45,6 +56,7 @@ func TestAgentCommand_runForElection(t *testing.T) {
 	c.BootstrapExpect = 3
 	c.DevMode = true
 	c.DataDir = dir
+	c.HTTPAddr = "127.0.0.1:0"
 
 	a1 := NewAgent(c)
 	err = a1.Start()
@@ -72,6 +84,7 @@ func TestAgentCommand_runForElection(t *testing.T) {
 	c.BootstrapExpect = 3
 	c.DevMode = true
 	c.DataDir = dir
+	c.HTTPAddr = "127.0.0.1:0"
 
 	a2 := NewAgent(c)
 	err = a2.Start()
@@ -91,6 +104,7 @@ func TestAgentCommand_runForElection(t *testing.T) {
 	c.BootstrapExpect = 3
 	c.DevMode = true
 	c.DataDir = dir
+	c.HTTPAddr = "127.0.0.1:0"
 
 	a3 := NewAgent(c)
 	err = a3.Start()
@@ -141,6 +155,7 @@ func Test_getTargetNodes(t *testing.T) {
 	}
 	c.DevMode = true
 	c.DataDir = dir
+	c.HTTPAddr = "127.0.0.1:0"
 
 	a1 := NewAgent(c)
 	_ = a1.Start()
@@ -163,6 +178,7 @@ func Test_getTargetNodes(t *testing.T) {
 	}
 	c.DevMode = true
 	c.DataDir = dir
+	c.HTTPAddr = "127.0.0.1:0"
 
 	a2 := NewAgent(c)
 	_ = a2.Start()
@@ -187,6 +203,7 @@ func Test_getTargetNodes(t *testing.T) {
 	}
 	c.DevMode = true
 	c.DataDir = dir
+	c.HTTPAddr = "127.0.0.1:0"
 
 	a3 := NewAgent(c)
 	_ = a3.Start()
@@ -341,6 +358,7 @@ func TestEncrypt(t *testing.T) {
 	c.LogLevel = logLevel
 	c.DevMode = true
 	c.DataDir = dir
+	c.HTTPAddr = "127.0.0.1:0"
 
 	a := NewAgent(c)
 	_ = a.Start()
@@ -369,6 +387,7 @@ func Test_advertiseRPCAddr(t *testing.T) {
 	c.LogLevel = logLevel
 	c.DevMode = true
 	c.DataDir = dir
+	c.HTTPAddr = "127.0.0.1:0"
 
 	a := NewAgent(c)
 	_ = a.Start()
@@ -401,6 +420,7 @@ func Test_bindRPCAddr(t *testing.T) {
 	c.DevMode = true
 	c.DataDir = dir
 	c.AdvertiseAddr = c.BindAddr
+	c.HTTPAddr = "127.0.0.1:0"
 
 	a := NewAgent(c)
 	err = a.Start()
@@ -431,6 +451,7 @@ func TestAgentConfig(t *testing.T) {
 	c.LogLevel = logLevel
 	c.DataDir = dir
 	c.DevMode = true
+	c.HTTPAddr = "127.0.0.1:0"
 
 	a := NewAgent(c)
 	_ = a.Start()
@@ -651,16 +672,15 @@ func TestAgent_RaftNotInitializedNoPanic(t *testing.T) {
 	c.DataDir = dir
 
 	a := NewAgent(c)
-	
+
 	// Call methods that access a.raft before Start() is called
 	// These should not panic
 	assert.False(t, a.IsLeader(), "IsLeader should return false when raft is not initialized")
-	
+
 	leader := a.Leader()
 	assert.Equal(t, "", string(leader), "Leader should return empty string when raft is not initialized")
-	
+
 	member, err := a.leaderMember()
 	assert.Nil(t, member, "leaderMember should return nil when raft is not initialized")
 	assert.Equal(t, ErrLeaderNotFound, err, "leaderMember should return ErrLeaderNotFound when raft is not initialized")
 }
-

--- a/dkron/api_test.go
+++ b/dkron/api_test.go
@@ -51,7 +51,7 @@ func setupAPITest(t *testing.T, port string) (dir string, a *Agent) {
 }
 
 func TestAPIJobCreateUpdate(t *testing.T) {
-	port := "8091"
+	port := getFreePort(t)
 	baseURL := fmt.Sprintf("http://localhost:%s/v1", port)
 	dir, _ := setupAPITest(t, port)
 	defer os.RemoveAll(dir)
@@ -103,7 +103,7 @@ func TestAPIJobCreateUpdate(t *testing.T) {
 }
 
 func TestAPIJobCreateUpdateParentJob_SameParent(t *testing.T) {
-	resp := postJob(t, "8092", []byte(`{
+	resp := postJob(t, getFreePort(t), []byte(`{
 		"name": "test_job",
 		"schedule": "@every 1m",
 		"command": "date",
@@ -121,7 +121,7 @@ func TestAPIJobCreateUpdateParentJob_SameParent(t *testing.T) {
 }
 
 func TestAPIJobCreateUpdateParentJob_NoParent(t *testing.T) {
-	resp := postJob(t, "8093", []byte(`{
+	resp := postJob(t, getFreePort(t), []byte(`{
 		"name": "test_job",
 		"schedule": "@every 1m",
 		"command": "date",
@@ -140,7 +140,7 @@ func TestAPIJobCreateUpdateParentJob_NoParent(t *testing.T) {
 }
 
 func TestAPIJobCreateUpdateParentJob_KeepDependents(t *testing.T) {
-	port := "8111"
+	port := getFreePort(t)
 	baseURL := fmt.Sprintf("http://localhost:%s/v1", port)
 	dir, a := setupAPITest(t, port)
 	defer os.RemoveAll(dir)
@@ -197,7 +197,7 @@ func TestAPIJobCreateUpdateParentJob_KeepDependents(t *testing.T) {
 }
 
 func TestAPIJobCreateUpdateValidationBadName(t *testing.T) {
-	resp := postJob(t, "8094", []byte(`{
+	resp := postJob(t, getFreePort(t), []byte(`{
 		"name": "BAD JOB NAME!",
 		"schedule": "@every 1m",
 		"executor": "shell",
@@ -209,7 +209,7 @@ func TestAPIJobCreateUpdateValidationBadName(t *testing.T) {
 }
 
 func TestAPIJobCreateUpdateValidationValidName(t *testing.T) {
-	resp := postJob(t, "8095", []byte(`{
+	resp := postJob(t, getFreePort(t), []byte(`{
 		"name": "abcdefghijklmnopqrstuvwxyz0123456789-_ßñëäïüøüáéíóýćàèìòùâêîôûæšłç",
 		"schedule": "@every 1m",
 		"executor": "shell",
@@ -221,7 +221,7 @@ func TestAPIJobCreateUpdateValidationValidName(t *testing.T) {
 }
 
 func TestAPIJobCreateUpdateValidationEmptyName(t *testing.T) {
-	port := "8101"
+	port := getFreePort(t)
 	baseURL := fmt.Sprintf("http://localhost:%s/v1", port)
 	dir, a := setupAPITest(t, port)
 	defer os.RemoveAll(dir)
@@ -254,7 +254,7 @@ func TestAPIJobCreateUpdateValidationEmptyName(t *testing.T) {
 }
 
 func TestAPIJobCreateUpdateValidationBadSchedule(t *testing.T) {
-	resp := postJob(t, "8097", []byte(`{
+	resp := postJob(t, getFreePort(t), []byte(`{
 		"name": "testjob",
 		"schedule": "@at badtime",
 		"executor": "shell",
@@ -266,7 +266,7 @@ func TestAPIJobCreateUpdateValidationBadSchedule(t *testing.T) {
 }
 
 func TestAPIJobCreateUpdateValidationBadConcurrency(t *testing.T) {
-	resp := postJob(t, "8098", []byte(`{
+	resp := postJob(t, getFreePort(t), []byte(`{
 		"name": "testjob",
 		"schedule": "@every 1m",
 		"executor": "shell",
@@ -279,7 +279,7 @@ func TestAPIJobCreateUpdateValidationBadConcurrency(t *testing.T) {
 }
 
 func TestAPIJobCreateUpdateValidationBadTimezone(t *testing.T) {
-	resp := postJob(t, "8099", []byte(`{
+	resp := postJob(t, getFreePort(t), []byte(`{
 		"name": "testjob",
 		"schedule": "@every 1m",
 		"executor": "shell",
@@ -292,7 +292,7 @@ func TestAPIJobCreateUpdateValidationBadTimezone(t *testing.T) {
 }
 
 func TestAPIJobCreateUpdateValidationBadShellExecutorTimeout(t *testing.T) {
-	resp := postJob(t, "8099", []byte(`{
+	resp := postJob(t, getFreePort(t), []byte(`{
 		"name": "testjob",
 		"schedule": "@every 1m",
 		"executor": "shell",
@@ -304,7 +304,7 @@ func TestAPIJobCreateUpdateValidationBadShellExecutorTimeout(t *testing.T) {
 }
 
 func TestAPIGetNonExistentJobReturnsNotFound(t *testing.T) {
-	port := "8096"
+	port := getFreePort(t)
 	baseURL := fmt.Sprintf("http://localhost:%s/v1", port)
 	dir, a := setupAPITest(t, port)
 	defer os.RemoveAll(dir)
@@ -316,7 +316,7 @@ func TestAPIGetNonExistentJobReturnsNotFound(t *testing.T) {
 }
 
 func TestAPIJobCreateUpdateJobWithInvalidParentIsNotCreated(t *testing.T) {
-	port := "8100"
+	port := getFreePort(t)
 	baseURL := fmt.Sprintf("http://localhost:%s/v1", port)
 	dir, a := setupAPITest(t, port)
 	defer os.RemoveAll(dir)
@@ -346,7 +346,7 @@ func TestAPIJobCreateUpdateJobWithInvalidParentIsNotCreated(t *testing.T) {
 }
 
 func TestAPIJobRestore(t *testing.T) {
-	port := "8109"
+	port := getFreePort(t)
 	baseURL := fmt.Sprintf("http://localhost:%s/v1/restore", port)
 	dir, a := setupAPITest(t, port)
 	defer os.RemoveAll(dir)
@@ -383,7 +383,7 @@ func TestAPIJobRestore(t *testing.T) {
 }
 
 func TestAPIJobOutputTruncate(t *testing.T) {
-	port := "8190"
+	port := getFreePort(t)
 	baseURL := fmt.Sprintf("http://localhost:%s/v1", port)
 	dir, a := setupAPITest(t, port)
 	defer os.RemoveAll(dir)
@@ -493,7 +493,7 @@ func postJob(t *testing.T, port string, jsonStr []byte) *http.Response {
 // TestAPILeaderEndpointsNoRaftNoPanic tests that leader-related endpoints
 // don't panic when accessed before Raft is fully initialized (issue #1702)
 func TestAPILeaderEndpointsNoRaftNoPanic(t *testing.T) {
-	port := "8095"
+	port := getFreePort(t)
 	baseURL := fmt.Sprintf("http://localhost:%s/v1", port)
 
 	dir, err := ioutil.TempDir("", "dkron-test")
@@ -542,7 +542,7 @@ func TestAPILeaderEndpointsNoRaftNoPanic(t *testing.T) {
 }
 
 func TestAPIPauseUnpause(t *testing.T) {
-	port := "8102"
+	port := getFreePort(t)
 	baseURL := fmt.Sprintf("http://localhost:%s/v1", port)
 	dir, a := setupAPITest(t, port)
 	defer os.RemoveAll(dir)
@@ -610,7 +610,7 @@ func TestAPIPauseUnpause(t *testing.T) {
 }
 
 func TestHealthEndpoint(t *testing.T) {
-	port := "8099"
+	port := getFreePort(t)
 	healthURL := fmt.Sprintf("http://localhost:%s/health", port)
 	dir, a := setupAPITest(t, port)
 	defer os.RemoveAll(dir)
@@ -639,7 +639,7 @@ func TestHealthEndpoint(t *testing.T) {
 }
 
 func TestPrometheusMetricsEndpoint(t *testing.T) {
-	port := "8103"
+	port := getFreePort(t)
 	metricsURL := fmt.Sprintf("http://localhost:%s/metrics", port)
 
 	dir, err := ioutil.TempDir("", "dkron-test")

--- a/dkron/grpc_test.go
+++ b/dkron/grpc_test.go
@@ -36,6 +36,7 @@ func TestGRPCExecutionDone(t *testing.T) {
 	c.BootstrapExpect = 1
 	c.DevMode = true
 	c.DataDir = dir
+	c.HTTPAddr = "127.0.0.1:0"
 
 	a := NewAgent(c)
 	_ = a.Start()

--- a/dkron/job_test.go
+++ b/dkron/job_test.go
@@ -126,6 +126,7 @@ func Test_isRunnable(t *testing.T) {
 	c.Server = true
 	c.LogLevel = logLevel
 	c.DevMode = true
+	c.HTTPAddr = "127.0.0.1:0"
 
 	a := NewAgent(c)
 	a.GRPCClient = &gRPCClientMock{}


### PR DESCRIPTION
Use OS-assigned ephemeral ports (127.0.0.1:0) for tests that don't need to make HTTP requests, and a getFreePort(t) helper for API tests that need to know the port. This replaces all hardcoded port numbers that caused conflicts when tests ran in parallel.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure to use dynamic port allocation instead of fixed ports, improving test reliability and preventing port conflicts during concurrent test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->