### PR TITLE
fix: assign job ID to job name in job creation/update handler

### DIFF
--- a/dkron/api.go
+++ b/dkron/api.go
@@ -304,6 +304,7 @@ func (h *HTTPTransport) jobCreateOrUpdateHandler(c *gin.Context) {
 			job.Owner = accessor
 		}
 	}
+	job.ID = job.Name
 
 	// Validate job
 	if err := job.Validate(); err != nil {

--- a/dkron/api_test.go
+++ b/dkron/api_test.go
@@ -75,6 +75,7 @@ func TestAPIJobCreateUpdate(t *testing.T) {
 	var origJob Job
 	err = json.Unmarshal(body, &origJob)
 	require.NoError(t, err)
+	assert.Equal(t, origJob.Name, origJob.ID)
 
 	jsonStr1 := []byte(`{
 		"name": "test_job",
@@ -97,6 +98,7 @@ func TestAPIJobCreateUpdate(t *testing.T) {
 	}
 
 	assert.Equal(t, origJob.Name, overwriteJob.Name)
+	assert.Equal(t, overwriteJob.Name, overwriteJob.ID)
 	assert.False(t, overwriteJob.Disabled)
 	assert.NotEqual(t, origJob.ExecutorConfig["command"], overwriteJob.ExecutorConfig["command"])
 	assert.Equal(t, "test", overwriteJob.ExecutorConfig["command"])

--- a/scripts/ansible/site.yml
+++ b/scripts/ansible/site.yml
@@ -7,7 +7,7 @@
   become_method: sudo
 
   vars:
-    version: 4.0.9
+    version: 4.1.1
 
   tasks:
     - name: Copy package


### PR DESCRIPTION
This pull request introduces a minor bug fix and a dependency update. The main change ensures that the `Job.ID` field is always set to match the `Job.Name`, improving consistency in job identification. Additionally, the Ansible deployment script is updated to use a newer version.

**Job handling improvements:**

* Ensured that `job.ID` is always set to the value of `job.Name` when creating or updating jobs in `HTTPTransport`, improving consistency and preventing potential mismatches.
* Added and updated tests in `api_test.go` to assert that `Job.ID` matches `Job.Name` after creation and update, verifying the fix. [[1]](diffhunk://#diff-870bd75f2dad71f723e8ee93691740b380077e337fa0120ae015a1bcf4c2cba6R78) [[2]](diffhunk://#diff-870bd75f2dad71f723e8ee93691740b380077e337fa0120ae015a1bcf4c2cba6R101)

**Dependency updates:**

* Updated the `version` variable in the Ansible playbook (`site.yml`) from `4.0.9` to `4.1.1` to deploy the latest package version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Job creation and updates now consistently keep the job name and ID aligned in API responses.
  * Added stronger checks to ensure create and overwrite flows return matching values.

* **Chores**
  * Updated the packaged Dkron beta version used by installation scripts to `4.1.1`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->