### PR TITLE
feat(grpc): refactor SetExecution to use applySetExecution method

### DIFF
--- a/dkron/agent.go
+++ b/dkron/agent.go
@@ -136,6 +136,8 @@ type Agent struct {
 	// pauseNewJobs controls whether new jobs can be created or updated
 	pauseNewJobs bool
 	pauseMu      sync.RWMutex
+
+	isLeaderFn func() bool
 }
 
 // ProcessorFactory is a function type that creates a new instance
@@ -671,6 +673,9 @@ func (a *Agent) leaderMember() (*serf.Member, error) {
 
 // IsLeader checks if this server is the cluster leader
 func (a *Agent) IsLeader() bool {
+	if a.isLeaderFn != nil {
+		return a.isLeaderFn()
+	}
 	if a.raft == nil {
 		return false
 	}

--- a/dkron/agent_execution.go
+++ b/dkron/agent_execution.go
@@ -1,0 +1,21 @@
+package dkron
+
+import (
+	"errors"
+
+	typesv1 "github.com/distribworks/dkron/v4/gen/proto/types/v1"
+)
+
+func (a *Agent) applySetExecution(execution *typesv1.Execution) error {
+	cmd, err := Encode(SetExecutionType, execution)
+	if err != nil {
+		return err
+	}
+
+	af := a.RaftApply(cmd)
+	if af == nil {
+		return errors.New("raft apply unavailable")
+	}
+
+	return af.Error()
+}

--- a/dkron/agent_execution.go
+++ b/dkron/agent_execution.go
@@ -7,6 +7,10 @@ import (
 )
 
 func (a *Agent) applySetExecution(execution *typesv1.Execution) error {
+	if !a.IsLeader() {
+		return ErrNotLeader
+	}
+
 	cmd, err := Encode(SetExecutionType, execution)
 	if err != nil {
 		return err

--- a/dkron/grpc.go
+++ b/dkron/grpc.go
@@ -7,9 +7,9 @@ import (
 	"net"
 	"time"
 
-	"github.com/hashicorp/go-metrics"
 	typesv1 "github.com/distribworks/dkron/v4/gen/proto/types/v1"
 	"github.com/distribworks/dkron/v4/plugin"
+	"github.com/hashicorp/go-metrics"
 	"github.com/hashicorp/raft"
 	"github.com/hashicorp/serf/serf"
 	"github.com/sirupsen/logrus"
@@ -435,14 +435,7 @@ func (grpcs *GRPCServer) SetExecution(ctx context.Context, execution *typesv1.Ex
 		"execution": execution.Key(),
 	}).Debug("grpc: Received SetExecution")
 
-	cmd, err := Encode(SetExecutionType, execution)
-	if err != nil {
-		grpcs.logger.WithError(err).Fatal("agent: encode error in SetExecution")
-		return nil, err
-	}
-	af := grpcs.agent.raft.Apply(cmd, raftTimeout)
-	if err := af.Error(); err != nil {
-		grpcs.logger.WithError(err).Fatal("agent: error applying SetExecutionType")
+	if err := grpcs.agent.applySetExecution(execution); err != nil {
 		return nil, err
 	}
 

--- a/dkron/grpc_test.go
+++ b/dkron/grpc_test.go
@@ -187,6 +187,27 @@ func TestGRPCExecutionDone(t *testing.T) {
 	})
 }
 
+func TestGRPCSetExecution_returns_error_when_raft_unavailable(t *testing.T) {
+	// Given
+	server := &GRPCServer{
+		agent:  &Agent{},
+		logger: getTestLogger(),
+	}
+	execution := &typesv1.Execution{
+		JobName:  "test",
+		NodeName: "testNode",
+	}
+
+	// When
+	var err error
+	require.NotPanics(t, func() {
+		_, err = server.SetExecution(context.Background(), execution)
+	})
+
+	// Then
+	require.EqualError(t, err, "raft apply unavailable")
+}
+
 func TestIsRetryableError(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/dkron/grpc_test.go
+++ b/dkron/grpc_test.go
@@ -190,7 +190,9 @@ func TestGRPCExecutionDone(t *testing.T) {
 func TestGRPCSetExecution_returns_error_when_raft_unavailable(t *testing.T) {
 	// Given
 	server := &GRPCServer{
-		agent:  &Agent{},
+		agent: &Agent{
+			isLeaderFn: func() bool { return true },
+		},
 		logger: getTestLogger(),
 	}
 	execution := &typesv1.Execution{
@@ -206,6 +208,24 @@ func TestGRPCSetExecution_returns_error_when_raft_unavailable(t *testing.T) {
 
 	// Then
 	require.EqualError(t, err, "raft apply unavailable")
+}
+
+func TestGRPCSetExecution_returns_error_when_not_leader(t *testing.T) {
+	// Given
+	server := &GRPCServer{
+		agent:  &Agent{},
+		logger: getTestLogger(),
+	}
+	execution := &typesv1.Execution{
+		JobName:  "test",
+		NodeName: "testNode",
+	}
+
+	// When
+	_, err := server.SetExecution(context.Background(), execution)
+
+	// Then
+	require.ErrorIs(t, err, ErrNotLeader)
 }
 
 func TestIsRetryableError(t *testing.T) {


### PR DESCRIPTION
This pull request refactors how the `SetExecution` operation is applied to the Raft cluster and improves error handling. The main logic for applying an execution is moved into a new method on the `Agent` type, which is now reused in the gRPC server. Additionally, a new test is added to ensure proper error handling when Raft is unavailable.

### Refactoring and Code Reuse

* Added a new `Agent.applySetExecution` method in `agent_execution.go` to encapsulate the logic for encoding and applying execution changes to Raft, improving code reuse and maintainability.
* Updated `GRPCServer.SetExecution` in `grpc.go` to use the new `applySetExecution` method, simplifying the method and centralizing error handling.

### Error Handling Improvements

* Enhanced error handling in `SetExecution`: now returns a clear error ("raft apply unavailable") if Raft is not available, instead of panicking or logging fatally. [[1]](diffhunk://#diff-35f209a9103be146bb50d1a4e83381fac698a1789d84718f346a0993fbf6c1b1R1-R21) [[2]](diffhunk://#diff-cfaecf5db704eb226c8acc12f9d5abdec2989cb22f17c84ac0962c13f1fc03f4L438-R438)
* Added a unit test `TestGRPCSetExecution_returns_error_when_raft_unavailable` in `grpc_test.go` to verify that the correct error is returned when Raft is unavailable.

### Minor Changes

* Reordered imports in `grpc.go` for consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved execution update handling to return explicit errors when the system cannot apply the change.
  * Ensured execution updates fail cleanly when the server is not the current leader, avoiding misleading success responses.
* **Tests**
  * Added unit tests for execution updates to confirm correct error behavior when apply is unavailable and when leadership requirements are not met.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->