### PR TITLE
fix: advertise reachable raft leader address

### DIFF
--- a/dkron/agent.go
+++ b/dkron/agent.go
@@ -642,6 +642,11 @@ func (a *Agent) StartServer() {
 	if err := a.raftLayer.Open(raftl); err != nil {
 		a.logger.Fatal(err)
 	}
+	advertiseAddr, err := net.ResolveTCPAddr("tcp", a.advertiseRPCAddr())
+	if err != nil {
+		a.logger.WithError(err).Fatal("agent: Failed to resolve advertised RPC address")
+	}
+	a.raftLayer.SetAdvertiseAddr(advertiseAddr)
 
 	if err := a.setupRaft(); err != nil {
 		a.logger.WithError(err).Fatal("agent: Raft layer failed to start")
@@ -662,9 +667,12 @@ func (a *Agent) leaderMember() (*serf.Member, error) {
 	if a.raft == nil {
 		return nil, ErrLeaderNotFound
 	}
-	l := a.raft.Leader()
+	_, leaderID := a.raft.LeaderWithID()
+	if leaderID == "" {
+		return nil, ErrLeaderNotFound
+	}
 	for _, member := range a.serf.Members() {
-		if member.Tags["rpc_addr"] == string(l) {
+		if member.Name == string(leaderID) {
 			return &member, nil
 		}
 	}
@@ -697,7 +705,14 @@ func (a *Agent) Leader() raft.ServerAddress {
 	if a.raft == nil {
 		return ""
 	}
-	return a.raft.Leader()
+	leaderAddr, leaderID := a.raft.LeaderWithID()
+	if leaderID == "" {
+		return leaderAddr
+	}
+	if rpcAddr, err := a.serverLookup.ServerAddr(leaderID); err == nil {
+		return rpcAddr
+	}
+	return leaderAddr
 }
 
 // Servers returns a list of known server

--- a/dkron/agent_test.go
+++ b/dkron/agent_test.go
@@ -390,16 +390,20 @@ func Test_advertiseRPCAddr(t *testing.T) {
 	c.HTTPAddr = "127.0.0.1:0"
 
 	a := NewAgent(c)
-	_ = a.Start()
-
-	time.Sleep(2 * time.Second)
+	require.NoError(t, a.Start())
+	t.Cleanup(func() { require.NoError(t, a.Stop()) })
+	require.Eventually(t, a.IsLeader, 5*time.Second, 100*time.Millisecond)
 
 	advertiseRPCAddr := a.advertiseRPCAddr()
 	exRPCAddr := "8.8.8.8:6868"
 
 	assert.Equal(t, exRPCAddr, advertiseRPCAddr)
+	assert.Equal(t, exRPCAddr, string(a.raftTransport.LocalAddr()))
+	assert.Equal(t, exRPCAddr, string(a.Leader()))
 
-	_ = a.Stop()
+	leader, err := a.leaderMember()
+	require.NoError(t, err)
+	assert.Equal(t, c.NodeName, leader.Name)
 }
 
 func Test_bindRPCAddr(t *testing.T) {

--- a/dkron/grpc.go
+++ b/dkron/grpc.go
@@ -189,7 +189,7 @@ func (grpcs *GRPCServer) ExecutionDone(ctx context.Context, execDoneReq *typesv1
 	// Get the leader address and compare with the current node address.
 	// Forward the request to the leader in case current node is not the leader.
 	if !grpcs.agent.IsLeader() {
-		addr := grpcs.agent.raft.Leader()
+		addr := grpcs.agent.Leader()
 		grpcs.agent.GRPCClient.ExecutionDone(string(addr), NewExecutionFromProto(execDoneReq.Execution))
 		return nil, ErrNotLeader
 	}
@@ -345,7 +345,7 @@ func (grpcs *GRPCServer) RaftGetConfiguration(ctx context.Context, in *emptypb.E
 	}
 
 	// Fill out the reply.
-	leader := grpcs.agent.raft.Leader()
+	_, leaderID := grpcs.agent.raft.LeaderWithID()
 	reply := &typesv1.RaftGetConfigurationResponse{}
 	reply.Index = future.Index()
 	for _, server := range future.Configuration().Servers {
@@ -362,7 +362,7 @@ func (grpcs *GRPCServer) RaftGetConfiguration(ctx context.Context, in *emptypb.E
 			Id:           string(server.ID),
 			Node:         node,
 			Address:      string(server.Address),
-			Leader:       server.Address == leader,
+			Leader:       server.ID == leaderID,
 			Voter:        server.Suffrage == raft.Voter,
 			RaftProtocol: raftProtocolVersion,
 		}

--- a/dkron/grpc_client.go
+++ b/dkron/grpc_client.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/go-metrics"
 	typesv1 "github.com/distribworks/dkron/v4/gen/proto/types/v1"
+	"github.com/hashicorp/go-metrics"
 	"github.com/sirupsen/logrus"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"golang.org/x/net/context"
@@ -172,7 +172,7 @@ func (grpcc *GRPCClient) Leave(addr string) error {
 func (grpcc *GRPCClient) SetJob(job *Job) error {
 	var conn *grpc.ClientConn
 
-	addr := grpcc.agent.raft.Leader()
+	addr := grpcc.agent.Leader()
 
 	// Initiate a connection with the server
 	conn, err := grpcc.Connect(string(addr))
@@ -204,7 +204,7 @@ func (grpcc *GRPCClient) SetJob(job *Job) error {
 func (grpcc *GRPCClient) DeleteJob(jobName string) (*Job, error) {
 	var conn *grpc.ClientConn
 
-	addr := grpcc.agent.raft.Leader()
+	addr := grpcc.agent.Leader()
 
 	// Initiate a connection with the server
 	conn, err := grpcc.Connect(string(addr))
@@ -243,7 +243,7 @@ func (grpcc *GRPCClient) DeleteExecutions(jobName string) (*Job, error) {
 
 	var conn *grpc.ClientConn
 
-	addr := grpcc.agent.raft.Leader()
+	addr := grpcc.agent.Leader()
 
 	// Initiate a connection with the server
 	conn, err := grpcc.Connect(string(addr))
@@ -278,7 +278,7 @@ func (grpcc *GRPCClient) DeleteExecutions(jobName string) (*Job, error) {
 func (grpcc *GRPCClient) RunJob(jobName string) (*Job, error) {
 	var conn *grpc.ClientConn
 
-	addr := grpcc.agent.raft.Leader()
+	addr := grpcc.agent.Leader()
 
 	// Initiate a connection with the server
 	conn, err := grpcc.Connect(string(addr))
@@ -402,7 +402,7 @@ func (grpcc *GRPCClient) GetActiveExecutions(addr string) ([]*typesv1.Execution,
 func (grpcc *GRPCClient) SetExecution(execution *typesv1.Execution) error {
 	var conn *grpc.ClientConn
 
-	addr := grpcc.agent.raft.Leader()
+	addr := grpcc.agent.Leader()
 
 	// Initiate a connection with the server
 	conn, err := grpcc.Connect(string(addr))
@@ -559,7 +559,7 @@ func (grpcc *GRPCClient) agentRunAttempt(addr string, job *typesv1.Job, executio
 
 		// Stream ends
 		if err == io.EOF {
-			addr := grpcc.agent.raft.Leader()
+			addr := grpcc.agent.Leader()
 			if err := grpcc.ExecutionDone(string(addr), NewExecutionFromProto(execution)); err != nil {
 				return err
 			}
@@ -575,7 +575,7 @@ func (grpcc *GRPCClient) agentRunAttempt(addr string, job *typesv1.Job, executio
 
 			grpcc.logger.WithError(err).Error(ErrBrokenStream)
 
-			addr := grpcc.agent.raft.Leader()
+			addr := grpcc.agent.Leader()
 			if err := grpcc.ExecutionDone(string(addr), NewExecutionFromProto(execution)); err != nil {
 				return err
 			}

--- a/dkron/raft_grpc.go
+++ b/dkron/raft_grpc.go
@@ -14,8 +14,9 @@ import (
 type RaftLayer struct {
 	TLSConfig *tls.Config
 
-	ln     net.Listener
-	logger *logrus.Entry
+	ln            net.Listener
+	advertiseAddr net.Addr
+	logger        *logrus.Entry
 }
 
 // NewRaftLayer returns an initialized unencrypted RaftLayer.
@@ -35,6 +36,13 @@ func NewTLSRaftLayer(tlsConfig *tls.Config, logger *logrus.Entry) *RaftLayer {
 func (t *RaftLayer) Open(l net.Listener) error {
 	t.ln = l
 	return nil
+}
+
+// SetAdvertiseAddr sets the reachable address Raft should publish for this
+// transport. The listener may be bound to an unspecified address, which is
+// valid for accepting connections but cannot be used as a dial target.
+func (t *RaftLayer) SetAdvertiseAddr(addr net.Addr) {
+	t.advertiseAddr = addr
 }
 
 // Dial opens a network connection.
@@ -67,7 +75,11 @@ func (t *RaftLayer) Close() error {
 	return t.ln.Close()
 }
 
-// Addr returns the binding address of the RaftLayer.
+// Addr returns the advertised address of the RaftLayer, falling back to the
+// binding address when no advertised address has been configured.
 func (t *RaftLayer) Addr() net.Addr {
+	if t.advertiseAddr != nil {
+		return t.advertiseAddr
+	}
 	return t.ln.Addr()
 }

--- a/dkron/raft_grpc_test.go
+++ b/dkron/raft_grpc_test.go
@@ -1,0 +1,22 @@
+package dkron
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRaftLayerAdvertiseAddr(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, listener.Close()) })
+
+	layer := NewRaftLayer(nil)
+	require.NoError(t, layer.Open(listener))
+	require.Equal(t, listener.Addr().String(), layer.Addr().String())
+
+	advertiseAddr := &net.TCPAddr{IP: net.ParseIP("192.0.2.1"), Port: 6868}
+	layer.SetAdvertiseAddr(advertiseAddr)
+	require.Equal(t, advertiseAddr.String(), layer.Addr().String())
+}


### PR DESCRIPTION
This pull request improves how the Dkron agent determines and advertises its network address for Raft communication, ensuring more accurate and reliable leader identification and client routing. The changes also refactor several internal APIs to consistently use the new address logic, and add tests to verify the new behavior.

**Raft layer address advertisement and leader resolution improvements:**

* Added support for configuring and retrieving an advertised Raft address in `RaftLayer`, allowing the agent to publish a reachable address even when the listener is bound to an unspecified address. (`dkron/raft_grpc.go`, `dkron/agent.go`) [[1]](diffhunk://#diff-5c63a1fb773138c4474a8fe1abb94846251a164fabd3a1c28653dfd3f5213202R18) [[2]](diffhunk://#diff-5c63a1fb773138c4474a8fe1abb94846251a164fabd3a1c28653dfd3f5213202R41-R47) [[3]](diffhunk://#diff-5c63a1fb773138c4474a8fe1abb94846251a164fabd3a1c28653dfd3f5213202L70-R83) [[4]](diffhunk://#diff-6dd78e50aaaa9b8c6848bc4586d068b656eb19c42fe3fd606a64e24eb17de46bR645-R649)
* Updated the agent's leader resolution logic to use node IDs instead of addresses, improving accuracy and resilience in identifying the current leader. (`dkron/agent.go`) [[1]](diffhunk://#diff-6dd78e50aaaa9b8c6848bc4586d068b656eb19c42fe3fd606a64e24eb17de46bL665-R675) [[2]](diffhunk://#diff-6dd78e50aaaa9b8c6848bc4586d068b656eb19c42fe3fd606a64e24eb17de46bL700-R715)

**API and internal refactoring for address handling:**

* Refactored all internal and gRPC client calls to use the new `Agent.Leader()` method instead of directly accessing `raft.Leader()`, ensuring consistent use of the advertised address throughout the codebase. (`dkron/grpc.go`, `dkron/grpc_client.go`) [[1]](diffhunk://#diff-cfaecf5db704eb226c8acc12f9d5abdec2989cb22f17c84ac0962c13f1fc03f4L192-R192) [[2]](diffhunk://#diff-cfaecf5db704eb226c8acc12f9d5abdec2989cb22f17c84ac0962c13f1fc03f4L348-R348) [[3]](diffhunk://#diff-cfaecf5db704eb226c8acc12f9d5abdec2989cb22f17c84ac0962c13f1fc03f4L365-R365) [[4]](diffhunk://#diff-128688d6d92a1d50bef48daa1fb5fb2d820f796c630602b9178de4c20c8f5908L175-R175) [[5]](diffhunk://#diff-128688d6d92a1d50bef48daa1fb5fb2d820f796c630602b9178de4c20c8f5908L207-R207) [[6]](diffhunk://#diff-128688d6d92a1d50bef48daa1fb5fb2d820f796c630602b9178de4c20c8f5908L246-R246) [[7]](diffhunk://#diff-128688d6d92a1d50bef48daa1fb5fb2d820f796c630602b9178de4c20c8f5908L281-R281) [[8]](diffhunk://#diff-128688d6d92a1d50bef48daa1fb5fb2d820f796c630602b9178de4c20c8f5908L405-R405) [[9]](diffhunk://#diff-128688d6d92a1d50bef48daa1fb5fb2d820f796c630602b9178de4c20c8f5908L562-R562) [[10]](diffhunk://#diff-128688d6d92a1d50bef48daa1fb5fb2d820f796c630602b9178de4c20c8f5908L578-R578)

**Testing and validation:**

* Improved the agent and Raft layer tests to verify correct advertisement and usage of the RPC address, including a new test for `RaftLayer`'s advertised address logic. (`dkron/agent_test.go`, `dkron/raft_grpc_test.go`) [[1]](diffhunk://#diff-6bcddc5b40ff214804160c5ea7ee97f6ccf373886ff3b7b29557066f082c2163L393-R406) [[2]](diffhunk://#diff-a8cd191650b7053cda9a8f1cf44912147a233b9089e3d7dd2e0da902987a2b9bR1-R22)

**Other:**

* Minor import ordering fix in `dkron/grpc_client.go` for consistency.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved leader discovery when nodes advertise an address different from their local network binding.
  - Ensured job execution, deletion, updates, and completion reporting are forwarded to the current leader correctly.
  - Improved cluster status reporting so the active leader is identified consistently.
  - Added support for explicitly advertised network addresses, with automatic fallback to the locally bound address when none is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->